### PR TITLE
chore: upgrade uuid to 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "node"
+  - "6"
+  - "4"
 
 # encrpyt channel name to get around issue
 # https://github.com/travis-ci/travis-ci/issues/1094

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-  "name":         "slugid",
-  "version":      "1.1.0",
-  "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
-  "description":  "URL-safe base64 UUID encoder for generating 22 character slugs",
-  "license":      "MIT",
+  "name": "slugid",
+  "version": "1.1.0",
+  "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
+  "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
+  "license": "MIT",
   "scripts": {
-    "test":   "nodeunit slugid_test.js"
+    "test": "nodeunit slugid_test.js"
   },
   "repository": {
-    "type":   "git",
-    "url":    "https://github.com/taskcluster/slugid.git"
+    "type": "git",
+    "url": "https://github.com/taskcluster/slugid.git"
   },
   "dependencies": {
-    "uuid":                             "^2.0.1"
+    "uuid": "^3.1.0",
+    "uuid-parse": "^1.0.0"
   },
   "devDependencies": {
-    "nodeunit":                         "0.8.6",
-    "browserify":                       "5.9.1"
+    "nodeunit": "0.8.6",
+    "browserify": "5.9.1"
   }
 }

--- a/slugid.js
+++ b/slugid.js
@@ -20,14 +20,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var uuid = require('uuid');
+var uuidv4 = require('uuid/v4');
+var uuidParse = require('uuid-parse');
 
 /**
  * Returns the given uuid as a 22 character slug. This can be a regular v4
  * slug or a "nice" slug.
  */
 exports.encode = function(uuid_) {
-  var bytes   = uuid.parse(uuid_);
+  var bytes   = uuidParse.parse(uuid_);
   var base64  = (new Buffer(bytes)).toString('base64');
   var slug = base64
               .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
@@ -44,14 +45,14 @@ exports.decode = function(slug) {
                   .replace(/-/g, '+')
                   .replace(/_/g, '/')
                   + '==';
-  return uuid.unparse(new Buffer(base64, 'base64'));
+  return uuidParse.unparse(new Buffer(base64, 'base64'));
 };
 
 /**
  * Returns a randomly generated uuid v4 compliant slug
  */
 exports.v4 = function() {
-  var bytes   = uuid.v4(null, new Buffer(16));
+  var bytes   = uuidv4(null, new Buffer(16));
   var base64  = bytes.toString('base64');
   var slug = base64
               .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
@@ -60,7 +61,7 @@ exports.v4 = function() {
   return slug;
 };
 
-/** 
+/**
  * Returns a randomly generated uuid v4 compliant slug which conforms to a set
  * of "nice" properties, at the cost of some entropy. Currently this means one
  * extra fixed bit (the first bit of the uuid is set to 0) which guarantees the
@@ -72,7 +73,7 @@ exports.v4 = function() {
  * restrict the range of potential uuids that may be generated.
  */
 exports.nice = function() {
-  var bytes   = uuid.v4(null, new Buffer(16));
+  var bytes   = uuidv4(null, new Buffer(16));
   bytes[0] = bytes[0] & 0x7f;  // unset first bit to ensure [A-Za-f] first char
   var base64  = bytes.toString('base64');
   var slug = base64

--- a/slugid_test.js
+++ b/slugid_test.js
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var slugid  = require('./slugid');
-var uuid    = require('uuid');
+var slugid = require('./slugid');
+var uuidv4 = require('uuid/v4');
 
 /**
  * Test that we can correctly encode a "non-nice" uuid (with first bit set) to
@@ -76,7 +76,7 @@ exports.uuidEncodeDecodeTest = function(test) {
 
   for (i = 0; i < 100; i++) {
     // Generate uuid
-    var uuid_ = uuid.v4();
+    var uuid_ = uuidv4();
 
     // Encode
     var slug = slugid.encode(uuid_);


### PR DESCRIPTION
I'd like to use `slugid` but I noticed it's using an older version of `uuid`, and I'd like to upgrade it to use the same version as other libs my app is already using.

Note that the `parse` and `unparse` functions were [removed from `uuid` in version 3](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but they were ported verbatim to another package named [`uuid-parse`](https://github.com/zefferus/uuid-parse), with the only changes being the use of `const` and `let` instead of `var` in a few places. Therefore, I also added `uuid-parse` as a new dependency, which makes `slugid` incompatible with Node versions below 4 (and may affect [browser compatibility](http://kangax.github.io/compat-table/es6/#test-const)). I think this is acceptable since Node versions below 4 have been [EOL since the end of 2016](https://github.com/nodejs/Release#release-schedule1). Just means we should bump the major version of `slugid` (to 2.0.0) on the next release.

BREAKING CHANGE: Requires Node 4+ due to use of ES6 language features in `uuid-parse` dependency

Also note that formatting of package.json was modified by the use of npm, namely from the commands `npm i --save uuid@latest` and `npm i --save uuid-parse`. It's probably a good idea to avoid custom formatting of package.json in general.