### PR TITLE
feat: make Buffer optional

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -25,11 +25,11 @@ tasks:
         description: Run tests with node v12
         command: npm test
       - image: node:14
-        command: npm test
         description: Run tests with node v14
-      - image: node:16
         command: npm test
+      - image: node:16
         description: Run tests with node v16
+        command: npm test
       - image: node:latest
         description: Run tests with latest node
         command: npm test

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,6 +23,7 @@ tasks:
         command: npm test
       - image: node:12
         description: Run tests with node v12
+        command: npm test
       - image: node:14
         command: npm test
         description: Run tests with node v14

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,18 +14,27 @@ tasks:
     environments:
       - image: node:6
         description: Run tests with node v6
+        command: npm test
       - image: node:8
         description: Run tests with node v8
+        command: npm test
       - image: node:10
         description: Run tests with node v10
+        command: npm test
       - image: node:12
         description: Run tests with node v12
       - image: node:14
+        command: npm test
         description: Run tests with node v14
       - image: node:16
+        command: npm test
         description: Run tests with node v16
       - image: node:latest
         description: Run tests with latest node
+        command: npm test
+      - image: node:latest
+        description: Run tests with latest node without Buffer
+        command: npm run test-nobuffer
   in:
     $if: tasks_for == "github-pull-request" && event["action"] in ["opened","reopened","synchronize"]
     then:
@@ -57,4 +66,4 @@ tasks:
               git config advice.detachedHead false &&
               git checkout --no-progress ${head_rev} &&
               npm install --no-progress . &&
-              npm test
+              ${env.command}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
   "license": "MIT",
   "scripts": {
-    "test": "nodeunit slugid_test.js"
+    "test": "nodeunit slugid_test.js",
+    "test-nobuffer": "NO_BUFFER=1 npm test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
   "license": "MIT",
   "scripts": {
-    "test": "nodeunit slugid_test.js"
+    "test": "nodeunit slugid_test.js && NO_BUFFER=1 nodeunit slugid_test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
   "license": "MIT",
   "scripts": {
-    "test": "nodeunit slugid_test.js && NO_BUFFER=1 nodeunit slugid_test.js"
+    "test": "nodeunit slugid_test.js"
   },
   "repository": {
     "type": "git",

--- a/slugid.js
+++ b/slugid.js
@@ -27,7 +27,7 @@ const toBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (bytes) => Buffer.from(bytes).toString('base64');
   }
-  return (bytes) => globalThis.btoa(String.fromCharCode(...bytes));
+  return (bytes) => btoa(String.fromCharCode(...bytes));
 })();
 
 /** @type {(base64: string) => Uint8Array | Buffer} */
@@ -35,7 +35,7 @@ const fromBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (base64) => Buffer.from(base64, 'base64');
   }
-  return (base64) => Uint8Array.from(globalThis.atob(base64), c => c.charCodeAt(0));
+  return (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
 })();
 
 /**

--- a/slugid.js
+++ b/slugid.js
@@ -23,7 +23,7 @@
 var uuid = require('uuid');
 
 /** @type {(bytes: Uint8Array) => string} */
-const toBase64 = (() => {
+var toBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (bytes) => Buffer.from(bytes).toString('base64');
   }
@@ -31,7 +31,7 @@ const toBase64 = (() => {
 })();
 
 /** @type {(base64: string) => Uint8Array | Buffer} */
-const fromBase64 = (() => {
+var fromBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (base64) => Buffer.from(base64, 'base64');
   }

--- a/slugid.js
+++ b/slugid.js
@@ -24,16 +24,16 @@ var uuid = require('uuid');
 
 /** @type {(bytes: Uint8Array) => string} */
 const toBase64 = (() => {
-  if (globalThis.Buffer) {
-    return (bytes) => globalThis.Buffer.from(bytes).toString('base64');
+  if (typeof Buffer !== 'undefined') {
+    return (bytes) => Buffer.from(bytes).toString('base64');
   }
   return (bytes) => btoa(String.fromCharCode(...bytes));
 })();
 
 /** @type {(base64: string) => Uint8Array | Buffer} */
 const fromBase64 = (() => {
-  if (globalThis.Buffer) {
-    return (base64) => globalThis.Buffer.from(base64, 'base64');
+  if (typeof Buffer !== 'undefined') {
+    return (base64) => Buffer.from(base64, 'base64');
   }
   return (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
 })();

--- a/slugid.js
+++ b/slugid.js
@@ -27,7 +27,7 @@ const toBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (bytes) => Buffer.from(bytes).toString('base64');
   }
-  return (bytes) => btoa(String.fromCharCode(...bytes));
+  return (bytes) => globalThis.btoa(String.fromCharCode(...bytes));
 })();
 
 /** @type {(base64: string) => Uint8Array | Buffer} */
@@ -35,7 +35,7 @@ const fromBase64 = (() => {
   if (typeof Buffer !== 'undefined') {
     return (base64) => Buffer.from(base64, 'base64');
   }
-  return (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  return (base64) => Uint8Array.from(globalThis.atob(base64), c => c.charCodeAt(0));
 })();
 
 /**

--- a/slugid.js
+++ b/slugid.js
@@ -22,13 +22,29 @@
 
 var uuid = require('uuid');
 
+/** @type {(bytes: Uint8Array) => string} */
+const toBase64 = (() => {
+  if (globalThis.Buffer) {
+    return (bytes) => globalThis.Buffer.from(bytes).toString('base64');
+  }
+  return (bytes) => btoa(String.fromCharCode(...bytes));
+})();
+
+/** @type {(base64: string) => Uint8Array | Buffer} */
+const fromBase64 = (() => {
+  if (globalThis.Buffer) {
+    return (base64) => globalThis.Buffer.from(base64, 'base64');
+  }
+  return (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+})();
+
 /**
  * Returns the given uuid as a 22 character slug. This can be a regular v4
  * slug or a "nice" slug.
  */
 exports.encode = function(uuid_) {
   var bytes   = uuid.parse(uuid_);
-  var base64  = Buffer.from(bytes).toString('base64');
+  var base64 = toBase64(bytes);
   var slug = base64
               .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
               .replace(/\//g, '_')  // Replace / with _ (see RFC 4648, sec. 5)
@@ -44,15 +60,15 @@ exports.decode = function(slug) {
                   .replace(/-/g, '+')
                   .replace(/_/g, '/')
                   + '==';
-  return uuid.stringify(Buffer.from(base64, 'base64'));
+  return uuid.stringify(fromBase64(base64));
 };
 
 /**
  * Returns a randomly generated uuid v4 compliant slug
  */
 exports.v4 = function() {
-  var bytes   = uuid.v4(null, Buffer.alloc(16));
-  var base64  = bytes.toString('base64');
+  var bytes   = uuid.v4(null, new Uint8Array(16));
+  var base64 = toBase64(bytes);
   var slug = base64
               .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
               .replace(/\//g, '_')  // Replace / with _ (see RFC 4648, sec. 5)
@@ -72,9 +88,9 @@ exports.v4 = function() {
  * restrict the range of potential uuids that may be generated.
  */
 exports.nice = function() {
-  var bytes   = uuid.v4(null, Buffer.alloc(16));
+  var bytes   = uuid.v4(null, new Uint8Array(16));
   bytes[0] = bytes[0] & 0x7f;  // unset first bit to ensure [A-Za-f] first char
-  var base64  = bytes.toString('base64');
+  var base64 = toBase64(bytes);
   var slug = base64
               .replace(/\+/g, '-')  // Replace + with - (see RFC 4648, sec. 5)
               .replace(/\//g, '_')  // Replace / with _ (see RFC 4648, sec. 5)

--- a/slugid_test.js
+++ b/slugid_test.js
@@ -23,7 +23,7 @@
 // Allows the tests to be run in environments with and without `Buffer`.
 if (process.env.NO_BUFFER === "1") {
   console.log('Removing `Buffer` from globalThis...');
-  delete globalThis.Buffer;
+  delete global.Buffer;
 }
 
 var slugid = require('./slugid');

--- a/slugid_test.js
+++ b/slugid_test.js
@@ -20,6 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Allows the tests to be run in environments with and without `Buffer`.
+if (process.env.NO_BUFFER === "1") {
+  console.log('Removing `Buffer` from globalThis...');
+  delete globalThis.Buffer;
+}
+
 var slugid = require('./slugid');
 var uuidv4 = require('uuid').v4;
 

--- a/slugid_test.js
+++ b/slugid_test.js
@@ -22,8 +22,8 @@
 
 // Allows the tests to be run in environments with and without `Buffer`.
 if (process.env.NO_BUFFER === "1") {
-  console.log('Removing `Buffer` from globalThis...');
   delete global.Buffer;
+  console.log('\x1b[33m' + 'Removed `Buffer` from globalThis.' + '\x1b[0m');
 }
 
 var slugid = require('./slugid');


### PR DESCRIPTION
Fixes #12

Thanks for this library! We use it extensively in https://github.com/higlass/higlass.

We recently upgraded our build and ran into #12. As mentioned in that issue, `uuid` does not have a dependency on Buffer,
so we _should_ be able to refactor the slugid internals and not require browser users to have a large Buffer polyfill. I made a shim for `slugid` in HiGlass (https://github.com/higlass/higlass/pull/1112), but I'd really prefer to keep a compatible `slugid` as a dependency.


## Changes

- adds `toBase64` and `fromBase64` which are built on `Buffer` or `atob`/`btoa`
- test suite runs twice, once with `Buffer` as a global and once with `Buffer` removed from `globalThis`.

`btoa` and `atob` are deprecated in Node.js, so this PR inspects `globalThis` for a `Buffer`. If it's present (polyfill or Node), 
then it will use the module. Otherwise it is assumed the environment has `atob` and `btoa` (browser), and will avoid the use of `Buffer` for 
encoding/decoding uuids.

cc: @pkerpedjiev 