### PR TITLE
chore!: drop support for Node 14 and 16

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,12 +12,6 @@ tasks:
       then: ${event.pull_request.head.repo.html_url}
       else: ${event.repository.html_url}
     environments:
-      - image: node:14
-        description: Run tests with node v14
-        command: yarn test
-      - image: node:16
-        description: Run tests with node v16
-        command: yarn test
       - image: node:18
         description: Run tests with node v18
         command: yarn test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/taskcluster/slugid/issues"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "uuid": "^9.0.0"


### PR DESCRIPTION
Node 16 hit EOL on 2023-09-11.

Release schedule here https://nodejs.dev/en/about/releases.