### PR TITLE
fix: missing 'main' entry on manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
   "license": "MIT",
   "main": "./src/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "test": "mocha",
     "test-nobuffer": "NO_BUFFER=1 yarn test"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "URL-safe base64 UUID encoder for generating 22 character slugs",
   "license": "MIT",
+  "main": "./src/index.js",
   "scripts": {
     "test": "mocha",
     "test-nobuffer": "NO_BUFFER=1 yarn test"


### PR DESCRIPTION
closes #31 

![image](https://github.com/taskcluster/slugid/assets/13461315/c1294c4a-9405-4da5-9c96-3c21c01c05c6)
